### PR TITLE
support the option `ignore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ And /path/to/package.json
 
 - options `Object` 
     - data `Object` the data which will be substituted into the template file.
+    - ignore `String|String[]` the ignore rule or a array of rules.
     - renderer `Object=ejs` the renderer to compile the template and apply data. The default renderer is [`ejs`](http://www.npmjs.org/package/ejs) created by TJ.
     - override `Boolean=false` whether should override existing files
     - noBackup `Boolean=false` if noBackup is `false`, a `.bak` file will be saved when overriding an existing file.

--- a/index.js
+++ b/index.js
@@ -141,6 +141,7 @@ Scaffold.prototype._globDir = function (root, callback) {
   glob('**/*', {
     cwd: root,
     dot: true,
+    ignore: this.options.ignore,
     // Then, the dirs in `files` will end with a slash `/`
     mark: true
   }, function (err, files) {

--- a/test/scaffold-generator.js
+++ b/test/scaffold-generator.js
@@ -61,6 +61,31 @@ describe("scaffold-generator", function(){
     });
   });
 
+  it(".copy(from, to, callback), ignore", function(done){
+    var to = tmp.make(fixtures);
+    var from = node_path.join(fixtures, 'template');
+    fs.write( node_path.join(to, 'lib/index.js'), 'abc');
+
+    scaffold({
+      data: {
+        name: 'cortex',
+        main: 'lib/index.js'
+      },
+      ignore: ['.gitignore']
+
+    }).copy(from, to, function (err) {
+      expect_file(to, expected, 'package.json');
+
+      // no change
+      expect( fs.read(node_path.join(to, 'lib/index.js')) ).to.equal('abc');
+      expect(err).to.equal(null);
+
+      // ignored file
+      expect( fs.exists(to, '.gitignore') ).to.equal(false);
+      done();
+    });
+  });
+
   it(".copy(from, to, callback), override=true, noBackup=true", function(done){
     var to = tmp.make(fixtures);
     var from = node_path.join(fixtures, 'template');


### PR DESCRIPTION
This fixes a bug of `cortex-scaffold-generator@4.1.5`, see [#31](https://github.com/cortexjs/cortex-scaffold-generator/issues/31).