### PR TITLE
Preserve file modes

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,7 +190,12 @@ Scaffold.prototype._copyFile = function (from, to, callback) {
         return callback(err);
       }
 
-      fse.outputFile(to, content, callback);
+      fs.stat(from, function(err, stats) {
+        if (err) {
+          return callback(err);
+        }
+          fse.outputFile(to, content, {mode : stats.mode }, callback);
+      });
     });
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scaffold-generator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "scaffold-generator",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi, here's a pull request to preserve the file modes when the scaffolding is run. Currently they are reset.

I'd be happy to add tests if you gave a little guidance as to what would be needed. My initial thought was to somehow add a mode test to the `expect_file` method.